### PR TITLE
Bug: Fix Lesson Category Title

### DIFF
--- a/backend/app/Http/Controllers/User/DashboardController.php
+++ b/backend/app/Http/Controllers/User/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\User;
 use App\Http\Controllers\Controller;
 use App\Models\ActivityLog;
 use App\Models\Category;
+use App\Models\Lesson;
 use App\Models\User;
 
 class DashboardController extends Controller
@@ -36,7 +37,8 @@ class DashboardController extends Controller
             }
             if ($activity['activity_type'] === 'Lesson')
             {
-                $name .= ' learned ' . Category::findOrFail($activity->activity_id)->title;
+                $lesson = Lesson::findOrFail($activity->activity_id);
+                $name .= ' learned ' . Category::findOrFail($lesson->category_id)->title;
             }
             
             $activities[] = [


### PR DESCRIPTION
### **Asana Link** 

- https://app.asana.com/0/1202627219907022/1202829352452277/f

### **Definition of Done**

 - I was confused why the category title didn't showed up. When I tried to investigate the activity_logs, I made a mistake that the activity_id was referred to the lesson->id... And when I tried to query it using Category model with activity->id passed through it It shows and error. So, this is how I fixed the problem.
 - [x] I fetched the lesson using activity->id and fetched the Category model with lesson->category_id

### **Notes**
- Currently, `breeze-next` recommend using localhost during local development of backend and frontend to avoid CORS "Same-Origin" issues.
Ref: https://github.com/laravel/breeze-next

### **Scenarios/Test Cases**

cd backend
- php artisan serve

cd frontend
- yarn || npm install
- yarn dev || npm run dev

### **Screenshots**
https://user-images.githubusercontent.com/108642414/185590027-516350ef-90ac-4c02-a7b1-e63f1e02c88e.mp4


